### PR TITLE
Fix e0063

### DIFF
--- a/src-tauri/src/appstate.rs
+++ b/src-tauri/src/appstate.rs
@@ -66,7 +66,9 @@ impl AppState {
             debug!("Removing interface");
             let mut client = self.client.clone();
             let request = RemoveInterfaceRequest {
-                interface_name: connection.interface_name.clone(),
+               interface_name: connection.interface_name.clone(),
+               post_down: None,
+               pre_down: None,
             };
             if let Err(error) = client.remove_interface(request).await {
                 error!("Failed to remove interface: {error}");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -73,6 +73,8 @@ pub async fn disconnect(location_id: i64, handle: AppHandle) -> Result<(), Error
         let mut client = state.client.clone();
         let request = RemoveInterfaceRequest {
             interface_name: connection.interface_name.clone(),
+            post_down: None,
+            pre_down: None,
         };
         if let Err(error) = client.remove_interface(request).await {
             error!("Failed to remove interface: {error}");

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -75,11 +75,13 @@ pub async fn setup_interface(
                 peers: vec![peer.clone()],
             };
             debug!("Creating interface {interface_config:#?}");
-            let request = CreateInterfaceRequest {
-                config: Some(interface_config.clone().into()),
-                allowed_ips,
-                dns: location.dns.clone(),
-            };
+           let request = CreateInterfaceRequest {
+               config: Some(interface_config.clone().into()),
+               allowed_ips,
+               dns: location.dns.clone(),
+               pre_up: None,
+               post_up: None,
+           };
             if let Err(error) = client.create_interface(request).await {
                 error!("Failed to create interface: {error}");
                 Err(Error::InternalError)

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -75,13 +75,13 @@ pub async fn setup_interface(
                 peers: vec![peer.clone()],
             };
             debug!("Creating interface {interface_config:#?}");
-           let request = CreateInterfaceRequest {
-               config: Some(interface_config.clone().into()),
-               allowed_ips,
-               dns: location.dns.clone(),
-               pre_up: None,
-               post_up: None,
-           };
+            let request = CreateInterfaceRequest {
+                config: Some(interface_config.clone().into()),
+                allowed_ips,
+                dns: location.dns.clone(),
+                pre_up: None,
+                post_up: None,
+             };
             if let Err(error) = client.create_interface(request).await {
                 error!("Failed to create interface: {error}");
                 Err(Error::InternalError)


### PR DESCRIPTION
Changes Made
appstate.rs and commands.rs:

Added post_down and pre_down fields to RemoveInterfaceRequest as None.
utils.rs:

Added pre_up and post_up fields to CreateInterfaceRequest as None.
Reason for Changes
To fix the E0063 Rust compiler errors by including all required fields in the structs.
The added fields are set as None since they might not be needed currently.