### PR TITLE
fix: handle active interface disconnect on quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ pnpm tauri dev
 ### Windows
 
 Remove `default-run` line from `[package]` section in `Cargo.toml` to build the project.
+
+# Legal
+
+  - *defguard is not an official WireGuard project, and WireGuard is a registered trademark of Jason A. Donenfeld.*

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@
 
 # defguard desktop client
 
-Desktop client for managing Wireguard VPN connections to [defguard](https://github.com/DefGuard/defguard) locations. Built with [tauri](https://tauri.app/) and [React.js](https://react.dev/)
+Desktop client for managing WireGuard VPN connections (any WireGuard server and [defguard](https://github.com/DefGuard/defguard) instances).
 
-![defguard desktop client](https://github.com/DefGuard/docs/blob/docs/releases/0.8/Defguard-Desktop-Client.png?raw=true)
+![defguard desktop client](https://defguard.net/images/product/client/main-screen.png)
 
+## Features
+
+- Supports any WireGuard server
+- Multi-platform - Linux, macOS & Windows
+- Detailed network overview - see all details of your connection history and statistics with real-time charts and logs
+- Multi-Factor Authentication with TOTP/Email & WireGuard PSK - Since WireGuard protocol doesn't support 2FA, most (if not all) available WireGuard clients use 2FA authorization to the "application" itself (not Wireguard tunnel). When using this client with [defguard VPN & SSO server](https://github.com/DefGuard/defguard) (which is <strong>free & open source</strong>) you will get <strong>real Multi-Factor Authentication using TOTP/Email codes + WireGuard Pre-shared session keys</strong>.
+- Multiple instances & locations - When combining with [defguard](https://github.com/DefGuard/defguard) VPN & SSO you can have multiple defguard instances (sites/installations) and multiple Locations (VPN tunnels in that location/site) in <strong>one client</strong>! If you are an admin/devops - all your customers (instances) and all their tunnels (locations) can be in one place!
+- Fast! - Built with Rust, [tauri](https://tauri.app/) and [React.js](https://react.dev/).
 
 To learn more about the system see our [documentation](https://defguard.gitbook.io).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "defguard-client",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel vite typesafe-i18n",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1170,7 +1170,7 @@ checksum = "7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b"
 
 [[package]]
 name = "defguard-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.21.6",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defguard-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Defguard desktop client"
 license = "Apache-2.0"
 homepage = "https://github.com/DefGuard/client"

--- a/src-tauri/src/appstate.rs
+++ b/src-tauri/src/appstate.rs
@@ -93,7 +93,10 @@ impl AppState {
     }
 
     pub async fn close_all_connections(&self) -> Result<(), crate::error::Error> {
-        for connection in self.get_connections() {
+        info!("Closing all active connections...");
+        let active_connections = self.get_connections();
+        info!("Found {} active connections", active_connections.len());
+        for connection in active_connections {
             debug!("Found active connection");
             trace!("Connection: {connection:#?}");
             debug!("Removing interface");

--- a/src-tauri/src/bin/defguard-client.rs
+++ b/src-tauri/src/bin/defguard-client.rs
@@ -179,7 +179,7 @@ async fn main() {
             });
         }
         _ => {
-          info!("Received event: {event:?}")
+            trace!("Received event: {event:?}")
         }
     });
 }

--- a/src-tauri/src/bin/defguard-client.rs
+++ b/src-tauri/src/bin/defguard-client.rs
@@ -178,6 +178,8 @@ async fn main() {
                 });
             });
         }
-        _ => {}
+        _ => {
+          info!("Received event: {event:?}")
+        }
     });
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -59,6 +59,7 @@ pub fn handle_tray_event(app: &AppHandle, event: SystemTrayEvent) {
         }
         SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
             "quit" => {
+                info!("Received QUIT request. Initiating shutdown...");
                 let app_state: State<AppState> = app.state();
                 tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(async {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "defguard-client",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "tauri": {
     "systemTray": {


### PR DESCRIPTION
Currently when pressing CMD+Q on macOS while a connection is active, the app shuts down without removing interfaces.

This adds an event handler to close all active connections.