### PR TITLE
fix: add missing maintainer field

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/DefGuard/client"
 default-run = "defguard-client"
 edition = "2021"
 rust-version = "1.60"
+authors = ["Defguard"]
 
 [build-dependencies]
 tauri-build = { version = "1.5", features = [] }


### PR DESCRIPTION
## 📖 Description

Added authors details to the cargo.toml file which is also used as the maintainer field in the resulting .deb package. Without the maintainer field, some apt commands would constantly display the following warning:

```
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 3474 package 'defgu
ard-client':
 missing 'Maintainer' field
 ```

Let me know if I should change the author to something more informative.

fixes #204 

Before:
```
> apt show ./defguard-client_0.3.0_amd64.deb
Package: defguard-client
Version: 0.3.0
Priority: optional
Maintainer:
...
 ```
 
 After:
 ```
> apt show ./defguard-client_0.3.0_amd64.deb
Package: defguard-client
Version: 0.3.0
Priority: optional
Maintainer: Defguard
...
```
 
### 🛠️ Dev Branch Merge Checklist:

#### Documentation ###

- [x] If testing requires changes in the environment or deployment, please **update the documentation** (https://defguard.gitbook.io) first and **attach the link to the documentation** section in this pool request
- [x] I have commented on my code, particularly in hard-to-understand areas

#### Testing ### 

- [x] I have performed manual tests manually and all changes work
- [x] New and existing unit tests pass locally with my changes

### 🏚️ Main Branch Merge Checklist:

#### Testing ### 

- [x] I have merged my changes before to dev and the dev checklist is done
- [x] I have tested all functionalities on the dev instance and they work

#### Documentation ###

- [x] I have made corresponding changes to the **user & admin documentation** and added new features documentation with screenshots for users/admins