### PR TITLE
Implements typestate pattern for all `id: Option<i64>` structs

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typesafe-i18n": "^5.26.2",
     "typescript": "^5.3.2",
     "typescript-eslint-language-service": "^5.0.5",
-    "vite": "^4.5.2"
+    "vite": "^4.5.3"
   },
   "volta": {
     "node": "20.5.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(@typescript-eslint/parser@6.13.1(eslint@8.55.0)(typescript@5.3.2))(eslint@8.55.0)(typescript@5.3.2)
       vite:
-        specifier: ^4.5.2
+        specifier: ^4.5.3
         version: 4.5.3(@types/node@20.10.3)(sass@1.69.5)
 
 packages:
@@ -1775,11 +1775,8 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
-  caniuse-lite@1.0.30001566:
-    resolution: {integrity: sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==}
-
-  caniuse-lite@1.0.30001651:
-    resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
+  caniuse-lite@1.0.30001658:
+    resolution: {integrity: sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -5798,7 +5795,7 @@ snapshots:
   autoprefixer@10.4.16(postcss@8.4.32):
     dependencies:
       browserslist: 4.22.2
-      caniuse-lite: 1.0.30001566
+      caniuse-lite: 1.0.30001658
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -5857,14 +5854,14 @@ snapshots:
 
   browserslist@4.22.2:
     dependencies:
-      caniuse-lite: 1.0.30001566
+      caniuse-lite: 1.0.30001658
       electron-to-chromium: 1.4.601
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
 
   browserslist@4.23.3:
     dependencies:
-      caniuse-lite: 1.0.30001651
+      caniuse-lite: 1.0.30001658
       electron-to-chromium: 1.5.9
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
@@ -5896,9 +5893,7 @@ snapshots:
 
   camelcase@7.0.1: {}
 
-  caniuse-lite@1.0.30001566: {}
-
-  caniuse-lite@1.0.30001651: {}
+  caniuse-lite@1.0.30001658: {}
 
   ccount@2.0.1: {}
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -177,7 +177,7 @@ pub async fn save_device_config(
     let device = response
         .device
         .expect("Missing device info in device config response");
-    let mut keys = WireguardKeys::new(instance.id, device.pubkey, private_key);
+    let keys = WireguardKeys::new(instance.id, device.pubkey, private_key);
     keys.save(&mut *transaction).await?;
     for location in response.configs {
         let new_location = device_config_to_location(location, instance.id);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -537,7 +537,7 @@ pub async fn last_connection(
     location_id: i64,
     connection_type: ConnectionType,
     app_state: State<'_, AppState>,
-) -> Result<Option<CommonConnection>, Error> {
+) -> Result<Option<CommonConnection<Id>>, Error> {
     debug!("Retrieving last connection for location {location_id} with type {connection_type:?}");
     if connection_type == ConnectionType::Location {
         if let Some(connection) =
@@ -717,8 +717,8 @@ pub async fn save_tunnel(mut tunnel: Tunnel, handle: AppHandle) -> Result<(), Er
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TunnelInfo {
-    pub id: Option<i64>,
+pub struct TunnelInfo<I = NoId> {
+    pub id: I,
     pub name: String,
     pub address: String,
     pub endpoint: String,
@@ -728,7 +728,7 @@ pub struct TunnelInfo {
 }
 
 #[tauri::command(async)]
-pub async fn all_tunnels(app_state: State<'_, AppState>) -> Result<Vec<TunnelInfo>, Error> {
+pub async fn all_tunnels(app_state: State<'_, AppState>) -> Result<Vec<TunnelInfo<Id>>, Error> {
     debug!("Retrieving all instances.");
 
     let tunnels = Tunnel::all(&app_state.get_pool()).await?;
@@ -741,7 +741,7 @@ pub async fn all_tunnels(app_state: State<'_, AppState>) -> Result<Vec<TunnelInf
 
     for tunnel in tunnels {
         tunnel_info.push(TunnelInfo {
-            id: tunnel.id,
+            id: tunnel.id.expect("Missing Tunnel ID"),
             name: tunnel.name,
             address: tunnel.address,
             endpoint: tunnel.endpoint,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -446,11 +446,11 @@ pub async fn location_stats(
     connection_type: ConnectionType,
     from: Option<String>,
     app_state: State<'_, AppState>,
-) -> Result<Vec<CommonLocationStats>, Error> {
+) -> Result<Vec<CommonLocationStats<Id>>, Error> {
     trace!("Location stats command received");
     let from = parse_timestamp(from)?.naive_utc();
     let aggregation = get_aggregation(from)?;
-    let stats: Vec<CommonLocationStats> = match connection_type {
+    let stats: Vec<CommonLocationStats<Id>> = match connection_type {
         ConnectionType::Location => LocationStats::all_by_location_id(
             &app_state.get_pool(),
             location_id,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -199,13 +199,13 @@ pub async fn save_device_config(
 }
 
 #[tauri::command(async)]
-pub async fn all_instances(app_state: State<'_, AppState>) -> Result<Vec<InstanceInfo>, Error> {
+pub async fn all_instances(app_state: State<'_, AppState>) -> Result<Vec<InstanceInfo<Id>>, Error> {
     debug!("Retrieving all instances.");
 
     let instances = Instance::all(&app_state.get_pool()).await?;
     debug!("Found ({}) instances", instances.len());
     trace!("Instances found: {instances:#?}");
-    let mut instance_info: Vec<InstanceInfo> = Vec::new();
+    let mut instance_info: Vec<InstanceInfo<Id>> = Vec::new();
     let connection_ids: Vec<i64> = app_state
         .get_connection_id_by_type(&ConnectionType::Location)
         .await;
@@ -218,8 +218,8 @@ pub async fn all_instances(app_state: State<'_, AppState>) -> Result<Vec<Instanc
         let keys = WireguardKeys::find_by_instance_id(&app_state.get_pool(), instance.id)
             .await?
             .ok_or(Error::NotFound)?;
-        instance_info.push(InstanceInfo {
-            id: Some(instance.id),
+        instance_info.push(InstanceInfo::<Id> {
+            id: instance.id,
             uuid: instance.uuid,
             name: instance.name,
             url: instance.url,

--- a/src-tauri/src/database/models/connection.rs
+++ b/src-tauri/src/database/models/connection.rs
@@ -142,6 +142,7 @@ pub struct ActiveConnection {
     pub interface_name: String,
     pub connection_type: ConnectionType,
 }
+
 impl ActiveConnection {
     #[must_use]
     pub fn new(

--- a/src-tauri/src/database/models/instance.rs
+++ b/src-tauri/src/database/models/instance.rs
@@ -147,8 +147,8 @@ impl Instance<NoId> {
 }
 
 #[derive(FromRow, Debug, Serialize, Deserialize)]
-pub struct InstanceInfo {
-    pub id: Option<i64>,
+pub struct InstanceInfo<I = NoId> {
+    pub id: I,
     pub name: String,
     pub uuid: String,
     pub url: String,

--- a/src-tauri/src/database/models/mod.rs
+++ b/src-tauri/src/database/models/mod.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub mod connection;
 pub mod instance;
 pub mod location;
@@ -8,5 +10,5 @@ pub mod wireguard_keys;
 
 // Typestate structs to make working with optional ids easier
 pub type Id = i64;
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct NoId;

--- a/src-tauri/src/database/models/wireguard_keys.rs
+++ b/src-tauri/src/database/models/wireguard_keys.rs
@@ -1,27 +1,45 @@
 use crate::{database::DbPool, error::Error};
 use sqlx::{query, query_as, Error as SqlxError};
 
+use super::{Id, NoId};
+
 // User key pair
 #[derive(Debug)]
-pub struct WireguardKeys {
-    pub id: Option<i64>,
+pub struct WireguardKeys<I = NoId> {
+    pub id: I,
     pub instance_id: i64,
     pub pubkey: String,
     pub prvkey: String,
 }
 
-impl WireguardKeys {
+impl WireguardKeys<Id> {
+    pub async fn find_by_instance_id(
+        pool: &DbPool,
+        instance_id: i64,
+    ) -> Result<Option<Self>, SqlxError> {
+        query_as!(
+            Self,
+            "SELECT id \"id: _\", instance_id, pubkey, prvkey \
+            FROM wireguard_keys WHERE instance_id = $1;",
+            instance_id
+        )
+        .fetch_optional(pool)
+        .await
+    }
+}
+
+impl WireguardKeys<NoId> {
     #[must_use]
     pub fn new(instance_id: i64, pubkey: String, prvkey: String) -> Self {
         WireguardKeys {
-            id: None,
+            id: NoId,
             instance_id,
             pubkey,
             prvkey,
         }
     }
 
-    pub async fn save<'e, E>(&mut self, executor: E) -> Result<(), Error>
+    pub async fn save<'e, E>(self, executor: E) -> Result<WireguardKeys<Id>, Error>
     where
         E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
     {
@@ -36,21 +54,11 @@ impl WireguardKeys {
         )
         .fetch_one(executor)
         .await?;
-        self.id = Some(result.id);
-        Ok(())
-    }
-
-    pub async fn find_by_instance_id(
-        pool: &DbPool,
-        instance_id: i64,
-    ) -> Result<Option<Self>, SqlxError> {
-        query_as!(
-            Self,
-            "SELECT id \"id?\", instance_id, pubkey, prvkey \
-            FROM wireguard_keys WHERE instance_id = $1;",
-            instance_id
-        )
-        .fetch_optional(pool)
-        .await
+        Ok(WireguardKeys::<Id> {
+            id: result.id,
+            instance_id: self.instance_id,
+            pubkey: self.pubkey,
+            prvkey: self.prvkey,
+        })
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use database::models::NoId;
 use serde::{Deserialize, Serialize};
 pub mod appstate;
 pub mod commands;
@@ -42,8 +43,8 @@ pub struct CommonWireguardFields {
 
 /// Common fields for Connection and TunnelConnection due to shared command
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CommonConnection {
-    pub id: Option<i64>,
+pub struct CommonConnection<I = NoId> {
+    pub id: I,
     pub location_id: i64,
     pub connected_from: String,
     pub start: NaiveDateTime,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,8 +54,8 @@ pub struct CommonConnection<I = NoId> {
 
 // Common fields for LocationStats and TunnelStats due to shared command
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CommonLocationStats {
-    pub id: Option<i64>,
+pub struct CommonLocationStats<I = NoId> {
+    pub id: I,
     pub location_id: i64,
     pub upload: i64,
     pub download: i64,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -31,12 +31,7 @@ pub async fn generate_tray_menu(app_state: State<'_, AppState>) -> Result<System
     if let Ok(instances) = all_instances {
         for instance in instances {
             let mut instance_menu = SystemTrayMenu::new();
-            let all_locations = all_locations(
-                instance.id,
-                app_state.clone(),
-            )
-            .await
-            .unwrap();
+            let all_locations = all_locations(instance.id, app_state.clone()).await.unwrap();
             debug!(
                 "All locations {:?} in instance {:?}",
                 all_locations, instance

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -32,7 +32,7 @@ pub async fn generate_tray_menu(app_state: State<'_, AppState>) -> Result<System
         for instance in instances {
             let mut instance_menu = SystemTrayMenu::new();
             let all_locations = all_locations(
-                instance.id.expect("Missing instannce id"),
+                instance.id,
                 app_state.clone(),
             )
             .await

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -16,7 +16,7 @@ use crate::{
     appstate::AppState,
     commands::{LocationInterfaceDetails, Payload},
     database::{
-        models::{location_stats::peer_to_location_stats, tunnel::peer_to_tunnel_stats, Id},
+        models::{location_stats::peer_to_location_stats, tunnel::peer_to_tunnel_stats, Id, NoId},
         ActiveConnection, Connection, DbPool, Location, Tunnel, TunnelConnection, WireguardKeys,
     },
     error::Error,
@@ -683,8 +683,8 @@ pub async fn disconnect_interface(
                 error!("Failed to remove interface: {error}");
                 return Err(Error::InternalError("Failed to remove interface".into()));
             }
-            let mut connection: Connection = active_connection.into();
-            connection.save(&state.get_pool()).await?;
+            let connection: Connection<NoId> = active_connection.into();
+            let connection = connection.save(&state.get_pool()).await?;
             trace!("Saved connection: {connection:#?}");
             debug!("Removed interface");
             debug!("Saving connection");

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -221,7 +221,7 @@ pub fn spawn_stats_thread(
                         interface_data.peers.into_iter().map(Into::into).collect();
                     for peer in peers {
                         if connection_type.eq(&ConnectionType::Location) {
-                            let mut location_stats = peer_to_location_stats(
+                            let location_stats = peer_to_location_stats(
                                 &peer,
                                 interface_data.listen_port,
                                 &state.get_pool(),
@@ -229,10 +229,10 @@ pub fn spawn_stats_thread(
                             .await
                             .unwrap();
                             debug!("Saving location stats: {location_stats:#?}");
-                            let _ = location_stats.save(&state.get_pool()).await;
-                            debug!("Saved location stats: {location_stats:#?}");
+                            let result = location_stats.save(&state.get_pool()).await;
+                            debug!("Saved location stats: {result:#?}");
                         } else {
-                            let mut tunnel_stats = peer_to_tunnel_stats(
+                            let tunnel_stats = peer_to_tunnel_stats(
                                 &peer,
                                 interface_data.listen_port,
                                 &state.get_pool(),
@@ -240,8 +240,8 @@ pub fn spawn_stats_thread(
                             .await
                             .unwrap();
                             debug!("Saving tunnel stats: {tunnel_stats:#?}");
-                            let _ = tunnel_stats.save(&state.get_pool()).await;
-                            debug!("Saved location stats: {tunnel_stats:#?}");
+                            let result = tunnel_stats.save(&state.get_pool()).await;
+                            debug!("Saved location stats: {result:#?}");
                         }
                     }
                 }

--- a/src-tauri/src/wg_config.rs
+++ b/src-tauri/src/wg_config.rs
@@ -110,6 +110,8 @@ pub fn parse_wireguard_config(config: &str) -> Result<Tunnel, WireguardConfigPar
 
 #[cfg(test)]
 mod test {
+    use crate::database::models::NoId;
+
     use super::*;
 
     #[test]
@@ -136,7 +138,7 @@ mod test {
             tunnel.prvkey,
             "GAA2X3DW0WakGVx+DsGjhDpTgg50s1MlmrLf24Psrlg="
         );
-        assert_eq!(tunnel.id, None);
+        assert_eq!(tunnel.id, NoId);
         assert_eq!(tunnel.name, "");
         assert_eq!(tunnel.address, "10.0.0.1/24");
         assert_eq!(

--- a/src/pages/client/clientAPI/clientApi.ts
+++ b/src/pages/client/clientAPI/clientApi.ts
@@ -137,6 +137,7 @@ export const clientApi = {
   updateInstance,
   parseTunnelConfig,
   saveTunnel,
+  updateTunnel,
   openLink,
   getTunnelDetails,
   getLatestAppVersion,

--- a/src/pages/client/clientAPI/clientApi.ts
+++ b/src/pages/client/clientAPI/clientApi.ts
@@ -94,6 +94,9 @@ const parseTunnelConfig = async (config: string) =>
 const saveTunnel = async (tunnel: TunnelRequest) =>
   invokeWrapper('save_tunnel', { tunnel: tunnel });
 
+const updateTunnel = async (tunnel: TunnelRequest) =>
+  invokeWrapper('update_tunnel', { tunnel: tunnel });
+
 const getLocationDetails = async (
   data: LocationDetailsRequest,
 ): Promise<LocationDetails> => invokeWrapper('location_interface_details', data);

--- a/src/pages/client/clientAPI/types.ts
+++ b/src/pages/client/clientAPI/types.ts
@@ -126,6 +126,7 @@ export type TauriCommandKey =
   | 'update_instance'
   | 'parse_tunnel_config'
   | 'save_tunnel'
+  | 'update_tunnel'
   | 'all_tunnels'
   | 'tunnel_details'
   | 'delete_tunnel'

--- a/src/pages/client/pages/ClientEditTunnelPage/components/EditTunnelFormCard.tsx
+++ b/src/pages/client/pages/ClientEditTunnelPage/components/EditTunnelFormCard.tsx
@@ -67,7 +67,7 @@ const defaultValues: FormFields = {
   pre_down: '',
   post_down: '',
 };
-const { saveTunnel } = clientApi;
+const { updateTunnel } = clientApi;
 
 const tunnelToForm = (tunnel: Tunnel): FormFields => {
   const {
@@ -186,7 +186,7 @@ export const EditTunnelFormCard = ({ tunnel, submitRef }: Props) => {
   );
 
   const handleValidSubmit: SubmitHandler<FormFields> = (values) => {
-    saveTunnel(values)
+    updateTunnel(values)
       .then(() => {
         navigate(routes.client.base, { replace: true });
         toaster.success(LL.pages.client.pages.editTunnelPage.messages.editSuccess());


### PR DESCRIPTION
Makes it easier to work with structures with optional ids by implementing the typestate pattern. All structures that come from database are now known to have id in place and null-checks are no longer necessary.