### PR TITLE
Fix automatic location disconnection when there is no traffic after connecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "defguard-client",
   "private": false,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "npm-run-all --parallel vite typesafe-i18n",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "defguard-client"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "defguard-dg"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "common",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 homepage = "https://github.com/DefGuard/client"
 license-file = "../LICENSE.md"
 rust-version = "1.80"
-version = "1.2.1"
+version = "1.2.2"
 
 [package]
 name = "defguard-client"

--- a/src-tauri/src/periodic/connection.rs
+++ b/src-tauri/src/periodic/connection.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use chrono::{NaiveDateTime, TimeDelta, Utc};
 use tauri::{AppHandle, Manager};
-use time::Time;
 use tokio::time::sleep;
 
 use crate::{
@@ -139,7 +138,7 @@ pub async fn verify_active_connections(app_handle: AppHandle) {
                                 // Check if there was any traffic since the connection was established
                                 // If not and the connection was established longer than the peer_alive_period,
                                 // consider the location dead and disconnect it later without reconnecting.
-                                let time_since_connection = Utc::now().naive_utc() - con.start;
+                                let time_since_connection = Utc::now() - con.start.and_utc();
                                 if latest_stat.collected_at < con.start {
                                     if time_since_connection > peer_alive_period {
                                         debug!(

--- a/src-tauri/src/periodic/connection.rs
+++ b/src-tauri/src/periodic/connection.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use chrono::{NaiveDateTime, TimeDelta, Utc};
 use tauri::{AppHandle, Manager};
+use time::Time;
 use tokio::time::sleep;
 
 use crate::{
@@ -135,17 +136,28 @@ pub async fn verify_active_connections(app_handle: AppHandle) {
                                 latest_stat.collected_at,
                                 peer_alive_period,
                             ) {
-                                // Check if there was any traffic since the connection was established.
-                                // If not, consider the location dead and disconnect it later without reconnecting.
+                                // Check if there was any traffic since the connection was established
+                                // If not and the connection was established longer than the peer_alive_period,
+                                // consider the location dead and disconnect it later without reconnecting.
+                                let time_since_connection = Utc::now().naive_utc() - con.start;
                                 if latest_stat.collected_at < con.start {
-                                    debug!(
-                                        "There wasn't any activity for Location {} since its \
-                                        connection at {}; considering it being dead and possibly \
-                                        broken. It will be disconnected without a further automatic \
-                                        reconnect.",
-                                        con.location_id, con.start
-                                    );
-                                    locations_to_disconnect.push((con.location_id, false));
+                                    if time_since_connection > peer_alive_period {
+                                        debug!(
+                                          "There wasn't any activity for Location {} since its \
+                                          connection at {}; considering it being dead and possibly \
+                                          broken. It will be terminated without a further automatic \
+                                          reconnect.",
+                                          con.location_id, con.start
+                                        );
+                                        locations_to_disconnect.push((con.location_id, false));
+                                    } else {
+                                        debug!(
+                                          "There wasn't any activity for Location {} since its \
+                                          connection at {}; The amount of time passed since the connection \
+                                          is {time_since_connection}, the connection will be terminated when it reaches \
+                                          {peer_alive_period}", 
+                                        con.location_id, con.start);
+                                    }
                                 } else {
                                     debug!(
                                         "There wasn't any activity for Location {} for the last \

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "defguard-client",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "tauri": {
     "systemTray": {


### PR DESCRIPTION
Disconnect location only if there is no traffic since connection start for longer than peer_alive_period