### PR TITLE
Socket permissions

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -35,6 +35,7 @@
     webkitgtk_4_1
     openssl
     libayatana-appindicator
+    desktop-file-utils
   ];
 
   nativeBuildInputs = with pkgs; [

--- a/resources-linux/defguard-service.service
+++ b/resources-linux/defguard-service.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Group=defguard
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/sbin/defguard-service
 KillMode=process

--- a/resources-linux/postinst
+++ b/resources-linux/postinst
@@ -1,3 +1,36 @@
-systemctl daemon-reload
-systemctl enable defguard-service
-systemctl start defguard-service
+#!/bin/sh
+set -e
+
+GROUP_NAME="defguard"
+
+case "$1" in
+    configure)
+        # Create the group if it doesn't exist
+        if ! getent group "$GROUP_NAME" >/dev/null; then
+            addgroup --system "$GROUP_NAME"
+            echo "Created group $GROUP_NAME"
+        fi
+        
+        # Determine target user
+        TARGET_USER=""
+        if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
+            TARGET_USER="$SUDO_USER"
+        elif [ -n "$USER" ] && [ "$USER" != "root" ]; then
+            TARGET_USER="$USER"
+        fi
+        
+        # Add user to group if we found a valid target
+        if [ -n "$TARGET_USER" ]; then
+            if getent passwd "$TARGET_USER" >/dev/null; then
+                usermod -a -G "$GROUP_NAME" "$TARGET_USER"
+                echo "Added user $TARGET_USER to group $GROUP_NAME"
+            fi
+        fi
+    ;;
+
+    # Enable and start background service
+    systemctl daemon-reload
+    systemctl enable defguard-service
+    systemctl start defguard-service
+esac
+

--- a/resources-linux/postinst
+++ b/resources-linux/postinst
@@ -52,3 +52,5 @@ case "$1" in
         ;;
 esac
 
+#DEBHELPER#
+

--- a/resources-linux/postinst
+++ b/resources-linux/postinst
@@ -2,6 +2,7 @@
 set -e
 
 GROUP_NAME="defguard"
+SERVICE_NAME="defguard-service"
 
 case "$1" in
     configure)
@@ -26,11 +27,28 @@ case "$1" in
                 echo "Added user $TARGET_USER to group $GROUP_NAME"
             fi
         fi
-    ;;
 
-    # Enable and start background service
-    systemctl daemon-reload
-    systemctl enable defguard-service
-    systemctl start defguard-service
+        # Handle systemd service
+        if [ -d /run/systemd/system ]; then
+            # Reload systemd to recognize new service file
+            systemctl daemon-reload
+            
+            # Enable service to start on boot
+            systemctl enable "$SERVICE_NAME"
+            
+            # Start the service now
+            systemctl start "$SERVICE_NAME"
+        fi
+        ;;
+    
+    abort-upgrade|abort-remove|abort-deconfigure)
+        # On failed operations, ensure service is running if it should be
+        if [ -d /run/systemd/system ]; then
+            systemctl daemon-reload
+            if systemctl is-enabled "$SERVICE_NAME" >/dev/null 2>&1; then
+                systemctl start "$SERVICE_NAME" || true
+            fi
+        fi
+        ;;
 esac
 

--- a/resources-linux/postrm
+++ b/resources-linux/postrm
@@ -1,1 +1,24 @@
-systemctl daemon-reload
+#!/bin/sh
+set -e
+
+GROUP_NAME="defguard"
+SERVICE_NAME="defguard-service"
+
+case "$1" in
+    remove)
+        # Service file still exists, just disable it
+        if [ -d /run/systemd/system ]; then
+            systemctl disable "$SERVICE_NAME" || true
+            systemctl daemon-reload
+        fi
+        ;;
+        
+    purge)
+        # Complete removal - clean up group too
+        if getent group "$GROUP_NAME" >/dev/null; then
+            delgroup "$GROUP_NAME" || true
+        fi
+        ;;
+esac
+
+#DEBHELPER#

--- a/resources-linux/prerm
+++ b/resources-linux/prerm
@@ -1,2 +1,15 @@
-systemctl stop defguard-service
-systemctl disable defguard-service
+#!/bin/sh
+set -e
+
+SERVICE_NAME="defguard-service"
+
+case "$1" in
+    remove|upgrade|deconfigure)
+        if [ -d /run/systemd/system ]; then
+            # Stop the service before removal/upgrade
+            systemctl stop "$SERVICE_NAME" || true
+        fi
+        ;;
+esac
+
+#DEBHELPER#

--- a/src-tauri/src/service/mod.rs
+++ b/src-tauri/src/service/mod.rs
@@ -350,8 +350,8 @@ pub async fn run_server(config: Config) -> anyhow::Result<()> {
     let uds = UnixListener::bind(DAEMON_SOCKET_PATH)?;
 
     // Set socket permissions to allow client access
-    // 0o666 allows read/write for owner, group, and others
-    fs::set_permissions(DAEMON_SOCKET_PATH, fs::Permissions::from_mode(0o666))?;
+    // 0o660 allows read/write for owner and group only
+    fs::set_permissions(DAEMON_SOCKET_PATH, fs::Permissions::from_mode(0o660))?;
 
     let uds_stream = UnixListenerStream::new(uds);
 


### PR DESCRIPTION
Adjust permissions on Unix socket to make it available only to users belonging to a specific group.
Update all relevant packages to setup the group and add the user to it as part of the install process.

Closes https://github.com/DefGuard/client/issues/551