### PR TITLE
Inform users about mismatch of UUIDs

### DIFF
--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -18,6 +18,7 @@ pub enum EventKey {
     AddInstance,
     MfaTrigger,
     VersionMismatch,
+    UuidMismatch,
 }
 
 impl From<EventKey> for &'static str {
@@ -34,6 +35,7 @@ impl From<EventKey> for &'static str {
             EventKey::AddInstance => "add-instance",
             EventKey::MfaTrigger => "mfa-trigger",
             EventKey::VersionMismatch => "version-mismatch",
+            EventKey::UuidMismatch => "uuid-mismatch",
         }
     }
 }

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -64,6 +64,9 @@ const en = {
         'Your Defguard instance "{instance_name: string}" version is not supported by your Defguard Client version. \
         Defguard Core version: {core_version: string} (required: {core_required_version: string}), Defguard Proxy version: {proxy_version: string} (required: {proxy_required_version: string}). \
         Please contact your administrator.',
+      uuidMismatch:
+        'The identifier (UUID) of the remote Defguard instance "{instance_name: string}" does not match the one stored locally. \
+        Because of this, some features may not work correctly. To resolve this issue, remove the instance and add it again, or contact your administrator.',
     },
   },
   components: {

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -193,6 +193,11 @@ type RootTranslation = {
 			 * @param {string} proxy_version
 			 */
 			versionMismatch: RequiredParams<'core_required_version' | 'core_version' | 'instance_name' | 'proxy_required_version' | 'proxy_version'>
+			/**
+			 * T​h​e​ ​i​d​e​n​t​i​f​i​e​r​ ​(​U​U​I​D​)​ ​o​f​ ​t​h​e​ ​r​e​m​o​t​e​ ​D​e​f​g​u​a​r​d​ ​i​n​s​t​a​n​c​e​ ​"​{​i​n​s​t​a​n​c​e​_​n​a​m​e​}​"​ ​d​o​e​s​ ​n​o​t​ ​m​a​t​c​h​ ​t​h​e​ ​o​n​e​ ​s​t​o​r​e​d​ ​l​o​c​a​l​l​y​.​ ​ ​ ​ ​ ​ ​ ​ ​ ​B​e​c​a​u​s​e​ ​o​f​ ​t​h​i​s​,​ ​s​o​m​e​ ​f​e​a​t​u​r​e​s​ ​m​a​y​ ​n​o​t​ ​w​o​r​k​ ​c​o​r​r​e​c​t​l​y​.​ ​T​o​ ​r​e​s​o​l​v​e​ ​t​h​i​s​ ​i​s​s​u​e​,​ ​r​e​m​o​v​e​ ​t​h​e​ ​i​n​s​t​a​n​c​e​ ​a​n​d​ ​a​d​d​ ​i​t​ ​a​g​a​i​n​,​ ​o​r​ ​c​o​n​t​a​c​t​ ​y​o​u​r​ ​a​d​m​i​n​i​s​t​r​a​t​o​r​.
+			 * @param {string} instance_name
+			 */
+			uuidMismatch: RequiredParams<'instance_name'>
 		}
 	}
 	components: {
@@ -1884,6 +1889,10 @@ export type TranslationFunctions = {
 			 * Your Defguard instance "{instance_name}" version is not supported by your Defguard Client version.         Defguard Core version: {core_version} (required: {core_required_version}), Defguard Proxy version: {proxy_version} (required: {proxy_required_version}).         Please contact your administrator.
 			 */
 			versionMismatch: (arg: { core_required_version: string, core_version: string, instance_name: string, proxy_required_version: string, proxy_version: string }) => LocalizedString
+			/**
+			 * The identifier (UUID) of the remote Defguard instance "{instance_name}" does not match the one stored locally.         Because of this, some features may not work correctly. To resolve this issue, remove the instance and add it again, or contact your administrator.
+			 */
+			uuidMismatch: (arg: { instance_name: string }) => LocalizedString
 		}
 	}
 	components: {

--- a/src/pages/client/ClientPage.tsx
+++ b/src/pages/client/ClientPage.tsx
@@ -110,6 +110,20 @@ export const ClientPage = () => {
       );
     });
 
+    const uuidMismatch = listen<{
+      instance_name: string;
+      local_uuid: string;
+      core_uuid: string;
+    }>(TauriEventKey.UUID_MISMATCH, (data) => {
+      const payload = data.payload;
+      toaster.error(
+        LL.common.messages.uuidMismatch({
+          instance_name: payload.instance_name,
+        }),
+        { lifetime: -1 },
+      );
+    });
+
     const locationUpdate = listen(TauriEventKey.LOCATION_UPDATE, () => {
       const invalidate = [clientQueryKeys.getLocations, clientQueryKeys.getTunnels];
       invalidate.forEach((key) => {
@@ -180,6 +194,7 @@ export const ClientPage = () => {
       appConfigChanged.then((cleanup) => cleanup());
       mfaTrigger.then((cleanup) => cleanup());
       verionMismatch.then((cleanup) => cleanup());
+      uuidMismatch.then((cleanup) => cleanup());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/client/types.ts
+++ b/src/pages/client/types.ts
@@ -114,4 +114,5 @@ export enum TauriEventKey {
   APPLICATION_CONFIG_CHANGED = 'application-config-changed',
   MFA_TRIGGER = 'mfa-trigger',
   VERSION_MISMATCH = 'version-mismatch',
+  UUID_MISMATCH = 'uuid-mismatch',
 }


### PR DESCRIPTION
Displays a one-time (per launch) warning about mismatch of the remote instance UUID with the one stored locally, which may cause numerous issues and will most probably happen often in the 1.5 version.