### PR TITLE
Fixes pentest issue DG25-29 from 2025-09-02

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "defguard_wireguard_rs"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093cede63322e14eede3916a6a5de2518788f438a6cdfc71d262c72d0ae865d0"
+checksum = "480e5be07e155d3fd4ff894a6348bc8eb9a3ddfacb681fc457445ec04135c0c6"
 dependencies = [
  "base64 0.22.1",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [".", "cli"]
 
 [workspace.dependencies]
 clap = { version = "4.5", features = ["cargo", "derive", "env"] }
-defguard_wireguard_rs = "0.7.6"
+defguard_wireguard_rs = "0.7.7"
 dirs-next = "2.0"
 prost = "0.14"
 reqwest = { version = "0.12", features = ["cookies", "json"] }


### PR DESCRIPTION
This pull request fixes vulnerability from penetration tests done by our security team on 2025-09-02:

- title: WireGuard configuration in the Defugard service logs
- ID: DG25-29
- report details: https://defguard.net/pentesting/

Bump defguard-wireguard-rs dependency to 0.7.7.

Related issue https://github.com/DefGuard/client/issues/564