### PR TITLE
fix nix setup for boringtun repo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758446476,
-        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
+        "lastModified": 1759632233,
+        "narHash": "sha256-krgZxGAIIIKFJS+UB0l8do3sYUDWJc75M72tepmVMzE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
+        "rev": "d7f52a7a640bc54c7bb414cca603835bf8dd4b10",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1758681214,
-        "narHash": "sha256-8cW731vev6kfr58cILO2ZsjHwaPhm88dQ8Q6nTSjP9I=",
+        "lastModified": 1759804383,
+        "narHash": "sha256-jPz0K8xsT2eNSratkw8bfPwSlTuOXGeUvz+bd9wq/vY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b12ed88d8d33d4f3cbc842bf29fad93bb1437299",
+        "rev": "dec08d5dfeca099b0058f0cc61264b04f33db42c",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -83,7 +83,7 @@ in
         ;
 
       fetcherVersion = 2;
-      hash = "sha256-QgHFIJv7BwzRQAzJ30+GhD5lCwVgASM0MwSwlRBWL4I=";
+      hash = "sha256-Qt4xC7BO7JZn236jXVe2VPAAFNnxdSJAvq+PYflW264=";
     };
 
     buildPhase = ''

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -68,6 +68,9 @@ in
 
     cargoDeps = rustPlatform.importCargoLock {
       lockFile = ../src-tauri/Cargo.lock;
+      outputHashes = {
+        "boringtun-0.6.0" = "sha256-UlgcnHAdrWm3S1v5T4W0froF4jJNqRAsfcVuI2EMSgk=";
+      };
     };
 
     # prefetch pnpm dependencies


### PR DESCRIPTION
After boringtun migration we need to handle a new git dependency in cargo.