### PR TITLE
add missing DEB & RPM dependencies

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -71,6 +71,9 @@
           "/usr/sbin/defguard-service": "target/release/defguard-service",
           "/lib/systemd/system/defguard-service.service": "../resources-linux/defguard-service.service"
         },
+        "depends": [
+          "desktop-file-utils"
+        ],
         "postInstallScript": "../resources-linux/postinst",
         "preRemoveScript": "../resources-linux/prerm",
         "postRemoveScript": "../resources-linux/postrm"


### PR DESCRIPTION
Add missing dependency for desktop-file-utils to DEB and RPM package config.

Should resolve https://github.com/DefGuard/client/issues/638