### PR TITLE
update helper provisioning scripts to include optional token expiration time

### DIFF
--- a/src-tauri/resources-windows/admin-scripts/GenerateEnrollmentTokensAD.ps1
+++ b/src-tauri/resources-windows/admin-scripts/GenerateEnrollmentTokensAD.ps1
@@ -15,7 +15,10 @@ param(
     [string]$ADUsername,
     
     [Parameter(Mandatory=$false)]
-    [string]$DomainController
+    [string]$DomainController,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$EnrollmentTokenExpirationTime
 )
 
 # Function to make authenticated API calls to Defguard
@@ -191,6 +194,11 @@ foreach ($username in $usernames) {
     $requestBody = @{
         email = $null
         send_enrollment_notification = $false
+    }
+    
+    # Add token expiration time if provided
+    if ($EnrollmentTokenExpirationTime) {
+        $requestBody["token_expiration_time"] = $EnrollmentTokenExpirationTime
     }
     
     $enrollmentResponse = Invoke-AuthenticatedRestMethod -Method "POST" -Endpoint $enrollmentEndpoint -Body $requestBody

--- a/src-tauri/resources-windows/admin-scripts/GenerateEnrollmentTokensEntraID.ps1
+++ b/src-tauri/resources-windows/admin-scripts/GenerateEnrollmentTokensEntraID.ps1
@@ -9,7 +9,10 @@ param(
     [string]$GroupName,
     
     [Parameter(Mandatory=$false)]
-    [string]$AttributeSetName = "Defguard"
+    [string]$AttributeSetName = "Defguard",
+    
+    [Parameter(Mandatory=$false)]
+    [string]$EnrollmentTokenExpirationTime
 )
 
 # Function to make authenticated API calls to Defguard
@@ -279,6 +282,11 @@ foreach ($username in $usernames) {
     $requestBody = @{
         email = $null
         send_enrollment_notification = $false
+    }
+    
+    # Add token expiration time if provided
+    if ($EnrollmentTokenExpirationTime) {
+        $requestBody["token_expiration_time"] = $EnrollmentTokenExpirationTime
     }
     
     $enrollmentResponse = Invoke-AuthenticatedRestMethod -Method "POST" -Endpoint $enrollmentEndpoint -Body $requestBody


### PR DESCRIPTION
Allow configuring enrollment token expiration time in helper scripts.

Related to https://github.com/DefGuard/defguard/issues/1669