### PR TITLE
Change create_dir to create_dir_all for default config directory creation

### DIFF
--- a/src-tauri/cli/src/bin/dg.rs
+++ b/src-tauri/cli/src/bin/dg.rs
@@ -2,7 +2,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::{
     fmt,
-    fs::{create_dir, OpenOptions},
+    fs::{create_dir_all, OpenOptions},
     net::IpAddr,
     path::{Path, PathBuf},
     str::FromStr,
@@ -594,7 +594,7 @@ async fn main() {
             if let Some(mut path) = dirs_next::data_dir() {
                 path.push("net.defguard.cli");
                 if !path.exists() {
-                    if let Err(err) = create_dir(&path) {
+                    if let Err(err) = create_dir_all(&path) {
                         error!("Failed to create default configuration path: {err}");
                         return;
                     }


### PR DESCRIPTION
## 📝 New contributors 

- [x] I have read, understand, and agree to the Contributor Agreement. By checking this box, I confirm I have the right to contribute this work and I grant Defguard sp. z o.o. the necessary rights to use my contribution as outlined in the full agreement.: https://tnt.sh/s/defguard-contribution-agreement

⚠︎ If the checkbox will not be confirmed - we can't include your contribution in our codebase.

## 📖 Description

1. replaced create_dir with create_dir_all to handle cases where some parent directories are missing

- [x] I have performed manual tests manually and all changes work

Hello, maintainers,

Apologies if I've formatted this PR incorrectly, but I genuinely encountered an issue that is resolved by changing these two lines of code. Even if this PR doesn't get merged, I kindly ask you to consider making these changes, as it might help others who run into the same problem as I did.

Here is the [issue](https://github.com/DefGuard/client/issues/729) I encountered

Thank you!