### PR TITLE
fixes missing dependencies for the nix builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765644376,
-        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1765766816,
-        "narHash": "sha256-m2au5a2x9L3ikyBi0g3/NRJSjmHVDvT42mn+O6FlyPs=",
+        "lastModified": 1767495280,
+        "narHash": "sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4f53a635709d82652567f51ef7af4365fbc0c88b",
+        "rev": "cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* Adds `iproute2` to the wrapped `defguard-service`
* Adds `update-desktop-database` to the wrapped `defguard-client`
* Tauri Builds on the GTK3/WebKitGTK4.1 stack, there was a mismatch with GTK4/WebKitGTK4.1, (GTK4 should use WebKitGTK6.0, but that isn't supported [yet](https://github.com/tauri-apps/tauri/pull/14684) for tauri.
* No `Makefile` so we can overwrite/rename `postInstall` with `installPhase`.
* Formatting

With these changes in place, it fixes issue [#728](https://github.com/DefGuard/client/issues/728).
