### PR TITLE
fix tray view opening with no locations

### DIFF
--- a/src-tauri/.sqlx/query-ed2bcb7a0bba8f3cee393b73367f38f262aa41551fc31a32bd91eefd22c4b870.json
+++ b/src-tauri/.sqlx/query-ed2bcb7a0bba8f3cee393b73367f38f262aa41551fc31a32bd91eefd22c4b870.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT EXISTS (SELECT 1 FROM tunnel);",
+  "describe": {
+    "columns": [
+      {
+        "name": "EXISTS (SELECT 1 FROM tunnel)",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ed2bcb7a0bba8f3cee393b73367f38f262aa41551fc31a32bd91eefd22c4b870"
+}

--- a/src-tauri/core/src/database/models/tunnel.rs
+++ b/src-tauri/core/src/database/models/tunnel.rs
@@ -129,6 +129,17 @@ impl Tunnel<Id> {
         Ok(tunnels)
     }
 
+    /// Returns `true` if there is at least one tunnel in the database.
+    pub async fn exists<'e, E>(executor: E) -> sqlx::Result<bool>
+    where
+        E: SqliteExecutor<'e>,
+    {
+        let result = query_scalar!("SELECT EXISTS (SELECT 1 FROM tunnel);")
+            .fetch_one(executor)
+            .await?;
+        Ok(result != 0)
+    }
+
     /// Find tunnels by name.
     pub async fn find_by_name<'e, E>(executor: E, name: &str) -> sqlx::Result<Vec<Self>>
     where

--- a/src-tauri/src/bin/defguard-client.rs
+++ b/src-tauri/src/bin/defguard-client.rs
@@ -164,11 +164,6 @@ async fn startup(app_handle: &AppHandle) {
     debug!("Tray menu has been re-generated successfully.");
 }
 
-/// Open the appropriate window, either the old or the new UI, depending if there are locations.
-fn open_appropriate_window(app_handle: &AppHandle) {
-    show_tray_or_full_view(app_handle);
-}
-
 fn main() {
     // Handle --version / -V before starting the GUI.
     check_version_flag("defguard-client");
@@ -238,7 +233,7 @@ fn main() {
             let is_deep_link = argv.iter().any(|a| a.starts_with("defguard://"));
             // User tried to spawn second instance, mirror tray left click path.
             if !is_deep_link {
-                open_appropriate_window(app);
+                show_tray_or_full_view(app);
             }
         }))
         .plugin(tauri_plugin_deep_link::init())
@@ -415,7 +410,7 @@ fn main() {
                 info!("App launched via deep link, opening full view directly.");
                 let _ = WindowManager::open_full_view(app_handle);
             } else {
-                open_appropriate_window(app_handle);
+                show_tray_or_full_view(app_handle);
             }
 
             info!("App setup completed, log level: {log_level}");
@@ -518,7 +513,7 @@ fn main() {
             ..
         } => {
             if !has_visible_windows {
-                open_appropriate_window(app_handle);
+                show_tray_or_full_view(app_handle);
             }
         }
         _ => {

--- a/src-tauri/src/bin/defguard-client.rs
+++ b/src-tauri/src/bin/defguard-client.rs
@@ -166,12 +166,7 @@ async fn startup(app_handle: &AppHandle) {
 
 /// Open the appropriate window, either the old or the new UI, depending if there are locations.
 fn open_appropriate_window(app_handle: &AppHandle) {
-    let has_locations = async_runtime::block_on(has_non_service_locations());
-    if has_locations {
-        let _ = WindowManager::open_tray(app_handle);
-    } else {
-        let _ = WindowManager::open_full_view(app_handle);
-    }
+    show_tray_or_full_view(app_handle);
 }
 
 fn main() {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -167,17 +167,6 @@ pub async fn setup_tray(app: &AppHandle) -> Result<(), Error> {
             {
                 let app = icon.app_handle();
 
-                let main_visible = app
-                    .get_webview_window(FULL_VIEW_WINDOW_ID)
-                    .and_then(|w| w.is_visible().ok())
-                    .unwrap_or(false);
-
-                if main_visible {
-                    if let Some(w) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
-                        let _ = w.hide();
-                    }
-                }
-
                 let tray_visible = app
                     .get_webview_window(COMPACT_WINDOW_ID)
                     .and_then(|w| w.is_visible().ok())

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -15,7 +15,7 @@ use crate::{
     database::{models::location::Location, DB_POOL},
     error::Error,
     events::EventKey,
-    window_manager::{show_tray_window, WindowManager, COMPACT_WINDOW_ID, FULL_VIEW_WINDOW_ID},
+    window_manager::{show_tray_or_full_view, COMPACT_WINDOW_ID, FULL_VIEW_WINDOW_ID},
     ConnectionType,
 };
 
@@ -188,17 +188,7 @@ pub async fn setup_tray(app: &AppHandle) -> Result<(), Error> {
                         let _ = w.hide();
                     }
                 } else {
-                    let has_locations = tauri::async_runtime::block_on(
-                        crate::window_manager::has_non_service_locations(),
-                    );
-                    if has_locations {
-                        if let Some(old_ui) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
-                            let _ = old_ui.hide();
-                        }
-                        show_tray_window(app);
-                    } else {
-                        let _ = WindowManager::open_full_view(app);
-                    }
+                    show_tray_or_full_view(app);
                 }
             }
         })
@@ -264,7 +254,7 @@ pub fn handle_tray_menu_event(app: &AppHandle, event: MenuEvent) {
             info!("Received QUIT request. Initiating shutdown...");
             handle.exit(0);
         }
-        TRAY_EVENT_SHOW => show_tray_window(app),
+        TRAY_EVENT_SHOW => show_tray_or_full_view(app),
         TRAY_EVENT_HIDE => hide_visible_windows(app),
         TRAY_EVENT_UPDATES => {
             let _ = webbrowser::open(SUBSCRIBE_UPDATES_LINK);

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -137,6 +137,13 @@ pub(crate) fn show_tray_window(app: &AppHandle) {
 /// otherwise fall back to the full view.
 pub fn show_tray_or_full_view(app: &AppHandle) {
     if block_on(has_non_service_locations()) {
+        // Hide the full view if it is open and visible (not minimized) so only the compact window is shown.
+        if let Some(full_view) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
+            let full_view_visible = full_view.is_visible().ok().unwrap_or(false);
+            if full_view_visible {
+                let _ = full_view.hide();
+            }
+        }
         show_tray_window(app);
     } else {
         let _ = WindowManager::open_full_view(app);

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(not(target_os = "windows"))]
 use tauri::Manager;
-use tauri::{AppHandle, Emitter, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri::{
+    async_runtime::block_on, AppHandle, Emitter, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+};
 
 use crate::{
     database::{models::location::Location, DB_POOL},
@@ -129,6 +131,16 @@ pub mod macos;
 // Export tauri commands so they can be registered in main.rs
 pub(crate) fn show_tray_window(app: &AppHandle) {
     let _ = WindowManager::open_tray(app);
+}
+
+/// Show the compact (tray) window when non-service locations exist,
+/// otherwise fall back to the full view.
+pub fn show_tray_or_full_view(app: &AppHandle) {
+    if block_on(has_non_service_locations()) {
+        show_tray_window(app);
+    } else {
+        let _ = WindowManager::open_full_view(app);
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -1,7 +1,6 @@
-#[cfg(not(target_os = "windows"))]
-use tauri::Manager;
 use tauri::{
-    async_runtime::block_on, AppHandle, Emitter, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+    async_runtime::block_on, AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow,
+    WebviewWindowBuilder,
 };
 
 use crate::{
@@ -163,7 +162,7 @@ pub fn open_full_view_window(app: AppHandle) {
 #[tauri::command]
 pub fn swap_to_full_view(app: AppHandle) {
     info!("swap_to_full_view called");
-    if let Some(window) = tauri::Manager::get_webview_window(&app, COMPACT_WINDOW_ID) {
+    if let Some(window) = app.get_webview_window(COMPACT_WINDOW_ID) {
         if let Err(err) = window.hide() {
             error!("swap_to_full_view task: Failed to hide new-ui window: {err:?}");
         }
@@ -179,7 +178,7 @@ pub fn swap_to_full_view(app: AppHandle) {
 pub fn close_tray_window(app: AppHandle) {
     info!("close_tray_window called");
 
-    if let Some(window) = tauri::Manager::get_webview_window(&app, COMPACT_WINDOW_ID) {
+    if let Some(window) = app.get_webview_window(COMPACT_WINDOW_ID) {
         info!("close_tray_window task: Hiding new-ui window");
         if let Err(err) = window.hide() {
             error!("close_tray_window task: Failed to hide new-ui window: {err:?}");
@@ -193,7 +192,7 @@ pub fn close_tray_window(app: AppHandle) {
 pub fn swap_to_tray(app: AppHandle) {
     info!("swap_to_tray called");
     show_tray_window(&app);
-    if let Some(window) = tauri::Manager::get_webview_window(&app, FULL_VIEW_WINDOW_ID) {
+    if let Some(window) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
         if let Err(err) = window.hide() {
             error!("swap_to_tray task: Failed to hide full-view window: {err:?}");
         }

--- a/src-tauri/src/window_manager/mod.rs
+++ b/src-tauri/src/window_manager/mod.rs
@@ -4,13 +4,25 @@ use tauri::{
 };
 
 use crate::{
-    database::{models::location::Location, DB_POOL},
+    database::{
+        models::{location::Location, tunnel::Tunnel},
+        DB_POOL,
+    },
     events::EventKey,
 };
 
 /// Returns `true` if there are any non-service locations in the database.
 pub async fn has_non_service_locations() -> bool {
     Location::exist(&*DB_POOL, false).await.unwrap_or_default()
+}
+
+/// Returns `true` if the compact (tray) view has anything to show: at least
+/// one non-service location or at least one tunnel.
+pub async fn has_tray_content() -> bool {
+    if has_non_service_locations().await {
+        return true;
+    }
+    Tunnel::exists(&*DB_POOL).await.unwrap_or_default()
 }
 
 pub const COMPACT_WINDOW_ID: &str = "compact-view";
@@ -132,10 +144,10 @@ pub(crate) fn show_tray_window(app: &AppHandle) {
     let _ = WindowManager::open_tray(app);
 }
 
-/// Show the compact (tray) window when non-service locations exist,
-/// otherwise fall back to the full view.
+/// Show the compact (tray) window when there is tray content (a non-service
+/// location or a tunnel), otherwise fall back to the full view.
 pub fn show_tray_or_full_view(app: &AppHandle) {
-    if block_on(has_non_service_locations()) {
+    if block_on(has_tray_content()) {
         // Hide the full view if it is open and visible (not minimized) so only the compact window is shown.
         if let Some(full_view) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
             let full_view_visible = full_view.is_visible().ok().unwrap_or(false);

--- a/src-tauri/src/window_manager/windows.rs
+++ b/src-tauri/src/window_manager/windows.rs
@@ -1,5 +1,6 @@
 use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
+use tauri::Manager;
 use windows::Win32::{
     Foundation::{LPARAM, RECT},
     Graphics::Gdi::{EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW},
@@ -144,13 +145,12 @@ impl WindowManager {
             .find(|m| m.is_primary)
             .unwrap_or(&monitors[0]);
 
-        let window =
-            if let Some(window) = tauri::Manager::get_webview_window(app, COMPACT_WINDOW_ID) {
-                let _ = window.unminimize();
-                window
-            } else {
-                Self::build_tray_window(app)?
-            };
+        let window = if let Some(window) = app.get_webview_window(COMPACT_WINDOW_ID) {
+            let _ = window.unminimize();
+            window
+        } else {
+            Self::build_tray_window(app)?
+        };
 
         let logical_width = COMPACT_WINDOW_WIDTH;
         let logical_height = COMPACT_WINDOW_HEIGHT;
@@ -247,18 +247,17 @@ impl WindowManager {
             primary.scale_factor
         );
 
-        info!("open_full_view: Checking if old-ui window exists");
-        let window =
-            if let Some(window) = tauri::Manager::get_webview_window(app, FULL_VIEW_WINDOW_ID) {
-                info!("open_full_view: old-ui window exists, unminimizing");
-                let _ = window.unminimize();
-                window
-            } else {
-                info!("open_full_view: old-ui window does not exist, building it");
-                let win = Self::build_full_view_window(app)?;
-                info!("open_full_view: old-ui window built successfully");
-                win
-            };
+        info!("open_full_view: Checking if full view window exists");
+        let window = if let Some(window) = app.get_webview_window(FULL_VIEW_WINDOW_ID) {
+            info!("open_full_view: full view window exists, unminimizing");
+            let _ = window.unminimize();
+            window
+        } else {
+            info!("open_full_view: full view window does not exist, building it");
+            let win = Self::build_full_view_window(app)?;
+            info!("open_full_view: full view window built successfully");
+            win
+        };
 
         info!("open_full_view: Querying outer_size");
         let outer_size = window.outer_size().unwrap_or(tauri::PhysicalSize {


### PR DESCRIPTION
Add a helper which opens the tray window or falls back to the full view if no non-service locations are configured.
This prevents opening an empty tray window by clicking on the Show button.

Closes https://github.com/DefGuard/client/issues/1025