### PR TITLE
Separate keychain for builds

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -26,9 +26,6 @@ jobs:
     env:
       APPLE_SIGNING_IDENTITY: "Apple Distribution: defguard sp. z o.o. (82GZ7KN29J)"
       APPLE_SIGNING_IDENTITY_INSTALLER: "3rd Party Mac Developer Installer: defguard sp. z o.o. (82GZ7KN29J)"
-      APPLE_PROVIDER_SHORT_NAME: "82GZ7KN29J"
-      APPLE_ID: "kamil@defguard.net"
-      APPLE_TEAM_ID: "82GZ7KN29J"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -72,9 +69,6 @@ jobs:
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/client-cli/Info.plist
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/tauri.macos.conf.json
 
-      - name: Unlock keychain
-        run: security -v unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" login.keychain
-
       - name: Build new UI
         run: |
           cd new-ui
@@ -90,11 +84,14 @@ jobs:
       - name: Build installation package
         run: |
           security -v unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          xcrun productbuild --sign "${{ env.APPLE_SIGNING_IDENTITY_INSTALLER }}" --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" /Applications defguard-client.pkg
-          xcrun altool --api-key ${{ secrets.APPLE_API_KEY }} --api-issuer ${{ secrets.APPLE_API_ISSUER }} --upload-app --platform macos --file defguard-client.pkg --wait
-          # xcrun notarytool submit --wait --apple-id ${{ env.APPLE_ID }} --password ${{ secrets.NOTARYTOOL_APP_SPECIFIC_PASSWORD }} --team-id ${{ env.APPLE_TEAM_ID }} defguard-client.pkg
-          # xcrun stapler staple defguard-client.pkg
+          xcrun productbuild --keychain build.keychain \
+            --sign "${{ env.APPLE_SIGNING_IDENTITY_INSTALLER }}" \
+            --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" \
+            /Applications defguard-client.pkg
+          xcrun altool --api-key ${{ secrets.APPLE_API_KEY }} \
+            --api-issuer ${{ secrets.APPLE_API_ISSUER }} \
+            --keychain build.keychain --upload-app --platform macos \
+            --file defguard-client.pkg --wait
 
       - name: Upload What's New
         env:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - dev
+      - better_build
       - "release/**"
     paths-ignore:
       - "*.md"
@@ -12,6 +13,8 @@ on:
       - v*.*.*
 
 env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   SQLX_OFFLINE: "1"
 
 jobs:
@@ -27,7 +30,7 @@ jobs:
       APPLE_ID: "kamil@defguard.net"
       APPLE_TEAM_ID: "82GZ7KN29J"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -47,6 +50,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          run_install: false
           version: 11
 
       - name: Install Node dependencies for New UI
@@ -58,6 +62,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Set build number
         run: |
@@ -80,30 +87,10 @@ jobs:
         with:
           args: --config src-tauri/tauri.app.conf.json --target universal-apple-darwin
 
-      # - name: Bundle Defguard CLI
-      #   env:
-      #     BUNDLE: "target/universal-apple-darwin/release/bundle/macos/Defguard.app"
-      #   run: |
-      #     cd src-tauri
-      #     mkdir -p ${BUNDLE}/Contents/Helpers/defguard-cli/Contents/MacOS
-      #     lipo -create -output ${BUNDLE}/Contents/Helpers/defguard-cli/Contents/MacOS/defguard-cli \
-      #       target/aarch64-apple-darwin/release/defguard-cli \
-      #       target/x86_64-apple-darwin/release/defguard-cli
-      #     ln -f client-cli/Info.plist ${BUNDLE}/Contents/Helpers/defguard-cli/Contents/Info.plist
-      #     pushd ${BUNDLE}/Contents/Helpers/defguard-cli/Contents
-      #     ln -f ../../../embedded.provisionprofile .
-      #     popd
-      #     codesign --verbose --force --options runtime \
-      #       --sign "${{ env.APPLE_SIGNING_IDENTITY }}" \
-      #       --prefix net.defguard. --entitlements Client.entitlements \
-      #       ${BUNDLE}/Contents/Helpers/defguard-cli
-      #     codesign --verbose --force --options runtime \
-      #       --sign "${{ env.APPLE_SIGNING_IDENTITY }}" \
-      #       --entitlements Client.entitlements ${BUNDLE}
-
       - name: Build installation package
         run: |
-          security -v unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" login.keychain
+          security -v unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
+          security default-keychain -s build.keychain
           xcrun productbuild --sign "${{ env.APPLE_SIGNING_IDENTITY_INSTALLER }}" --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" /Applications defguard-client.pkg
           xcrun altool --api-key ${{ secrets.APPLE_API_KEY }} --api-issuer ${{ secrets.APPLE_API_ISSUER }} --upload-app --platform macos --file defguard-client.pkg --wait
           # xcrun notarytool submit --wait --apple-id ${{ env.APPLE_ID }} --password ${{ secrets.NOTARYTOOL_APP_SPECIFIC_PASSWORD }} --team-id ${{ env.APPLE_TEAM_ID }} defguard-client.pkg

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - dev
-      - better_build
       - "release/**"
     paths-ignore:
       - "*.md"

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -89,9 +89,8 @@ jobs:
             --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" \
             /Applications defguard-client.pkg
           xcrun notarytool submit defguard-client.pkg \
-            --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8 \
-            --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
-            --issuer "${{ secrets.APPLE_API_ISSUER }}" \
+            --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8 \
+            --key-id "${{ secrets.APPLE_API_KEY }}" --issuer "${{ secrets.APPLE_API_ISSUER }}" \
             --wait
 
       - name: Upload What's New

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -83,15 +83,16 @@ jobs:
 
       - name: Build installation package
         run: |
-          security -v unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
+          security unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
           xcrun productbuild --keychain build.keychain \
             --sign "${{ env.APPLE_SIGNING_IDENTITY_INSTALLER }}" \
             --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" \
             /Applications defguard-client.pkg
-          xcrun altool --api-key ${{ secrets.APPLE_API_KEY }} \
-            --api-issuer ${{ secrets.APPLE_API_ISSUER }} \
-            --keychain build.keychain --upload-app --platform macos \
-            --file defguard-client.pkg --wait
+          xcrun notarytool submit defguard-client.pkg \
+            --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8 \
+            --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
+            --issuer "${{ secrets.APPLE_API_ISSUER }}" \
+            --wait
 
       - name: Upload What's New
         env:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -89,7 +89,7 @@ jobs:
             --component "src-tauri/target/universal-apple-darwin/release/bundle/macos/Defguard.app" \
             /Applications defguard-client.pkg
           xcrun notarytool submit defguard-client.pkg \
-            --key ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8 \
+            --key ~/.private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8 \
             --key-id "${{ secrets.APPLE_API_KEY }}" --issuer "${{ secrets.APPLE_API_ISSUER }}" \
             --wait
 

--- a/.github/workflows/posture.yaml
+++ b/.github/workflows/posture.yaml
@@ -44,10 +44,6 @@ jobs:
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::linux::setup1 -- --ignored
 
-      - name: Show sccache stats
-        run: sccache --show-stats
-
-
   test-linux-postures-encrypted:
     name: Linux postures - encrypted
     runs-on:
@@ -77,10 +73,6 @@ jobs:
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::linux::setup2 -- --ignored
 
-      - name: Show sccache stats
-        run: sccache --show-stats
-
-
   test-windows-postures-setup1:
     name: Windows postures - setup1
     runs-on:
@@ -105,9 +97,6 @@ jobs:
         shell: cmd
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::windows::setup1 -- --ignored
-
-      - name: Show sccache stats
-        run: sccache --show-stats
 
   test-windows-postures-setup2:
     name: Windows postures - setup2
@@ -134,9 +123,6 @@ jobs:
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::windows::setup2 -- --ignored
 
-      - name: Show sccache stats
-        run: sccache --show-stats
-
   test-macos-postures-unencrypted:
     name: macOS postures - unencrypted
     runs-on:
@@ -159,9 +145,6 @@ jobs:
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::macos::setup1 -- --ignored
 
-      - name: Show sccache stats
-        run: sccache --show-stats
-
   test-macos-postures-encrypted:
     name: macOS postures - encrypted
     runs-on:
@@ -183,6 +166,3 @@ jobs:
         working-directory: src-tauri/
         run: |
           cargo test -p defguard-client-posture --locked --lib inspector::tests::ci::macos::setup2 -- --ignored
-
-      - name: Show sccache stats
-        run: sccache --show-stats

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -62,7 +62,7 @@ jobs:
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/tauri.macos.conf.json
 
       - name: Unlock keychain
-        run: security -v unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" login.keychain
+        run: security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" login.keychain
 
       - name: Build new UI
         run: |

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -1,8 +1,6 @@
 name: Build macOS dmg
 on:
   push:
-    branches:
-      - better_build
   workflow_call:
     inputs:
       upload_url:
@@ -64,11 +62,6 @@ jobs:
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/client-cli/Info.plist
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/tauri.macos.conf.json
 
-      # - name: Unlock keychain
-      #   run: |
-      #     security unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
-      #     security default-keychain -s build.keychain
-
       - name: Build new UI
         run: |
           cd new-ui
@@ -86,12 +79,12 @@ jobs:
         with:
           args: --config src-tauri/tauri.dmg.conf.json --target universal-apple-darwin
 
-      # - name: Upload DMG
-      #   uses: shogo82148/actions-upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ inputs.upload_url }}
-      #     asset_path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/Defguard_${{ env.VERSION }}_universal.dmg
-      #     asset_content_type: application/x-apple-diskimage
-      #     overwrite: true
+      - name: Upload DMG
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/Defguard_${{ env.VERSION }}_universal.dmg
+          asset_content_type: application/x-apple-diskimage
+          overwrite: true

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -1,5 +1,8 @@
 name: Build macOS dmg
 on:
+  push:
+    branches:
+      - better_build
   workflow_call:
     inputs:
       upload_url:
@@ -61,8 +64,10 @@ jobs:
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/client-cli/Info.plist
           sed -i '' "s,@BUILD_NUMBER@,${{ github.run_number }}," src-tauri/tauri.macos.conf.json
 
-      - name: Unlock keychain
-        run: security unlock-keychain -p "${{ secrets.KEYCHAIN_PASSWORD }}" login.keychain
+      # - name: Unlock keychain
+      #   run: |
+      #     security unlock-keychain -p "${{ secrets.BUILD_KEYCHAIN_PASSWORD }}" build.keychain
+      #     security default-keychain -s build.keychain
 
       - name: Build new UI
         run: |
@@ -81,12 +86,12 @@ jobs:
         with:
           args: --config src-tauri/tauri.dmg.conf.json --target universal-apple-darwin
 
-      - name: Upload DMG
-        uses: shogo82148/actions-upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/Defguard_${{ env.VERSION }}_universal.dmg
-          asset_content_type: application/x-apple-diskimage
-          overwrite: true
+      # - name: Upload DMG
+      #   uses: shogo82148/actions-upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ inputs.upload_url }}
+      #     asset_path: src-tauri/target/universal-apple-darwin/release/bundle/dmg/Defguard_${{ env.VERSION }}_universal.dmg
+      #     asset_content_type: application/x-apple-diskimage
+      #     overwrite: true

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -8,6 +8,8 @@ on:
         type: string
 
 env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   SQLX_OFFLINE: "1"
 
 jobs:
@@ -17,7 +19,7 @@ jobs:
       - macOS
       - native
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -37,6 +39,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          run_install: false
           version: 11
 
       - name: Install Node dependencies for New UI
@@ -48,6 +51,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Set build number
         run: |

--- a/.github/workflows/release-macos.yaml
+++ b/.github/workflows/release-macos.yaml
@@ -1,6 +1,5 @@
 name: Build macOS dmg
 on:
-  push:
   workflow_call:
     inputs:
       upload_url:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -914,9 +914,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2372,14 +2372,16 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.74.0"
+version = "1.74.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "6be87932f10230a4339ab394edd8e4611fcb72553d8295b4d52ea55249b3daa5"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide",
+ "num-complex",
+ "pulp",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -4343,6 +4345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +5394,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5649,6 +5684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5673,6 +5717,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -9893,18 +9943,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Also:
* Use sccache to speed up macOS builds.
* Use `notarytool` in place of deprecated `altool`.