### PR TITLE
db: fix integer mismatch for download/upload

### DIFF
--- a/src-tauri/src/database/models/connection.rs
+++ b/src-tauri/src/database/models/connection.rs
@@ -63,8 +63,8 @@ pub struct ConnectionInfo {
     pub location_id: Id,
     pub start: NaiveDateTime,
     pub end: NaiveDateTime,
-    pub upload: Option<i32>,
-    pub download: Option<i32>,
+    pub upload: Option<i64>,
+    pub download: Option<i64>,
 }
 
 impl From<ConnectionInfo> for CommonConnectionInfo {

--- a/src-tauri/src/database/models/tunnel.rs
+++ b/src-tauri/src/database/models/tunnel.rs
@@ -534,8 +534,8 @@ pub struct TunnelConnectionInfo {
     pub tunnel_id: Id,
     pub start: NaiveDateTime,
     pub end: NaiveDateTime,
-    pub upload: Option<i32>,
-    pub download: Option<i32>,
+    pub upload: Option<i64>,
+    pub download: Option<i64>,
 }
 
 impl TunnelConnectionInfo {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,6 @@ pub struct CommonConnectionInfo {
     pub location_id: Id,
     pub start: NaiveDateTime,
     pub end: NaiveDateTime,
-    pub upload: Option<i32>,
-    pub download: Option<i32>,
+    pub upload: Option<i64>,
+    pub download: Option<i64>,
 }


### PR DESCRIPTION
## 📝 New contributors 

- [X] I have read, understand, and agree to the Contributor Agreement. By checking this box, I confirm I have the right to contribute this work and I grant Defguard sp. z o.o. the necessary rights to use my contribution as outlined in the full agreement.: https://tnt.sh/s/defguard-contribution-agreement

⚠︎ If the checkbox will not be confirmed - we can't include your contribution in our codebase.

## 📖 Description

upload/download are INTEGER in the database.
But while LocationStats (for example) has upload/download defined as i64, the model has it only as i32.

And when having >i32 values in the db, the log gets flooded with the following error:
[2026-07-20][10:12:02.440314676][ERROR][webview:vn@tauri://localhost/assets/index-D54brCyI.js:13:34411] Invoking "all_connections" failed due to unknown error: "Database error: error occurred while decoding column 5: out of range integral type conversion attempted"

This change should fix it.

### 🛠️ Dev Branch Merge Checklist:

#### Documentation ###

- [ ] If testing requires changes in the environment or deployment, please **update the documentation** (https://docs.defguard.net) first and **attach the link to the documentation** section in this pull request
- [X] I have commented on my code, particularly in hard-to-understand areas

#### Testing ###

- [X] I have performed manual tests manually and all changes work
- [X] New and existing unit tests pass locally with my changes

### 🏚️ Main Branch Merge Checklist:

#### Testing ###

- [ ] I have merged my changes before to dev and the dev checklist is done
- [ ] I have tested all functionalities on the dev instance and they work

#### Documentation ###

- [ ] I have made corresponding changes to the **user & admin documentation** and added new features documentation with screenshots for users/admins
