### PR TITLE
show Edge communication errors for posture-check-only locations

### DIFF
--- a/new-ui/src/shared/components/LocationCard/api/connectError.ts
+++ b/new-ui/src/shared/components/LocationCard/api/connectError.ts
@@ -6,6 +6,10 @@ const connectErrorSchema = z.discriminatedUnion('kind', [
     message: z.string(),
   }),
   z.object({
+    kind: z.literal('serviceUnavailable'),
+    message: z.string(),
+  }),
+  z.object({
     kind: z.literal('other'),
     message: z.string(),
   }),

--- a/new-ui/src/shared/components/LocationCard/components/LocationCardConnectButton.tsx
+++ b/new-ui/src/shared/components/LocationCard/components/LocationCardConnectButton.tsx
@@ -23,6 +23,8 @@ export const LocationCardConnectButton = () => {
       ) {
         setPostureError(connectError.message);
         setView(LocationCardViews.PostureCheckFail);
+      } else if (connectError?.kind === 'serviceUnavailable') {
+        setView(LocationCardViews.ConnectionError);
       }
     },
     meta: {

--- a/new-ui/src/shared/components/OverviewLocationCard/OverviewLocationCard.tsx
+++ b/new-ui/src/shared/components/OverviewLocationCard/OverviewLocationCard.tsx
@@ -53,6 +53,11 @@ export const OverviewLocationCard = ({ location, instance }: Props) => {
           view: ConnectModalView.PostureCheckFail,
           postureError: connectError.message,
         });
+      } else if (connectError?.kind === 'serviceUnavailable') {
+        useConnectModal.getState().open({
+          location,
+          view: ConnectModalView.ConnectionError,
+        });
       }
     },
     meta: {

--- a/src-tauri/core/src/error.rs
+++ b/src-tauri/core/src/error.rs
@@ -56,6 +56,8 @@ pub enum Error {
     HttpError(String),
     #[error("Posture check failed: {0}")]
     PostureCheckFailed(String),
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
 }
 
 // we must manually implement serde::Serialize

--- a/src-tauri/enterprise/posture/src/posture.rs
+++ b/src-tauri/enterprise/posture/src/posture.rs
@@ -76,7 +76,10 @@ pub async fn authorize_posture_session(location: &Location<Id>) -> Result<String
             );
             Err(Error::PostureCheckFailed(body.error))
         }
-        status => Err(Error::ServiceUnavailable(format!(
+        status if status.is_server_error() => Err(Error::ServiceUnavailable(format!(
+            "Unexpected proxy response: {status}"
+        ))),
+        status => Err(Error::HttpError(format!(
             "Unexpected proxy response: {status}"
         ))),
     }

--- a/src-tauri/enterprise/posture/src/posture.rs
+++ b/src-tauri/enterprise/posture/src/posture.rs
@@ -50,7 +50,7 @@ pub async fn authorize_posture_session(location: &Location<Id>) -> Result<String
     debug!("Sending posture check request to {proxy_url}");
     let response = post_with_headers(proxy_url, &request)
         .await
-        .map_err(|e| Error::HttpError(e.to_string()))?;
+        .map_err(|e| Error::ServiceUnavailable(e.to_string()))?;
 
     match response.status() {
         StatusCode::OK => {
@@ -76,7 +76,7 @@ pub async fn authorize_posture_session(location: &Location<Id>) -> Result<String
             );
             Err(Error::PostureCheckFailed(body.error))
         }
-        status => Err(Error::HttpError(format!(
+        status => Err(Error::ServiceUnavailable(format!(
             "Unexpected proxy response: {status}"
         ))),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -78,6 +78,8 @@ use crate::{
 pub enum ConnectError {
     #[error("Posture check failed: {0}")]
     PostureCheckFailed(String),
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
     #[error("{0}")]
     Other(String),
 }
@@ -86,6 +88,7 @@ impl From<Error> for ConnectError {
     fn from(error: Error) -> Self {
         match error {
             Error::PostureCheckFailed(message) => Self::PostureCheckFailed(message),
+            Error::ServiceUnavailable(message) => Self::ServiceUnavailable(message),
             error => Self::Other(error.to_string()),
         }
     }


### PR DESCRIPTION
Trigger the new "service unavailable" modal for locations which use just posture checks without MFA

Closes https://github.com/DefGuard/client/issues/1064